### PR TITLE
Update pycbc_submit_dax to fix early proxy expiration on ./start resubmissions.

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -489,7 +489,7 @@ if [ \${RESULT} -eq 0 ] ; then
     grid-proxy-info
   else
     cp /tmp/x509up_u\`id -u\` /tmp/x509up_u\`id -u\`.orig
-    grid-proxy-init -cert /tmp/x509up_u\`id -u\`.orig -key /tmp/x509up_u\`id -u\`.orig
+    grid-proxy-init -hours 276 -cert /tmp/x509up_u\`id -u\`.orig -key /tmp/x509up_u\`id -u\`.orig
     rm -f /tmp/x509up_u\`id -u\`.orig
     grid-proxy-info
   fi


### PR DESCRIPTION
Adding the -hours argument to grid-proxy-init in the case you do not have a RFC compliant proxy.  This prevents a failure mode where your workflow runs longer than 12 hours after you resubmit it and then all the jobs start to fail due to expired proxies.  276 hours is equal to the maximum standard proxy lifetime of 11.5 days that is created when you use ligo-proxy-init.